### PR TITLE
Enables email sending

### DIFF
--- a/conf/.env.template
+++ b/conf/.env.template
@@ -81,14 +81,14 @@ GUNICORN_MEDIA=0
 
 # Email Settings, see https://docs.djangoproject.com/en/3.2/ref/settings/#email-host
 # Required for email confirmation and password reset (automatically activates if host is set)
-# EMAIL_HOST='localhost'
-# EMAIL_PORT=25
-# EMAIL_HOST_USER=
-# EMAIL_HOST_PASSWORD=
-# EMAIL_USE_TLS=0
-# EMAIL_USE_SSL=0
+EMAIL_HOST='127.0.0.1'
+EMAIL_PORT=25
+EMAIL_HOST_USER=
+EMAIL_HOST_PASSWORD=
+EMAIL_USE_TLS=0
+EMAIL_USE_SSL=0
 # email sender address (default 'webmaster@localhost')
-# DEFAULT_FROM_EMAIL=
+DEFAULT_FROM_EMAIL=tandoor@__DOMAIN__
 # prefix used for account related emails (default "[Tandoor Recipes] ")
 # ACCOUNT_EMAIL_SUBJECT_PREFIX=
 


### PR DESCRIPTION
## Problem

- Tandoor is unable to send emails which is used for forgotten passwords and to invite users to spaces.

## Solution

- Set environment variables correctly to reference the postfix service installed by yunohost.

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
